### PR TITLE
use multiarch tags

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -13,6 +13,7 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -118,4 +119,15 @@ func GetNotDeletableTags(input *GetNotDeletableTagsInput) []string { //nolint:cy
 	}
 
 	return tagsNotToDelete
+}
+
+func GetTagWithoutArch(tagName string, tagArch []string) string {
+	formatedTag := tagName
+
+	for _, arch := range tagArch {
+		suffix := fmt.Sprintf("-%s", arch)
+		formatedTag = strings.TrimSuffix(formatedTag, suffix)
+	}
+
+	return formatedTag
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -178,3 +178,22 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("version %s is incorrect", version)
 	}
 }
+
+func TestGetTagWithoutArch(t *testing.T) {
+	t.Parallel()
+
+	tests := make(map[string]string)
+
+	tests["test1"] = "test1"
+	tests["test2-arm64"] = "test2"
+	tests["test3-amd64"] = "test3"
+
+	tagArch := []string{"amd64", "arm64"}
+
+	for in, out := range tests {
+		result := api.GetTagWithoutArch(in, tagArch)
+		if result != out {
+			t.Fatalf("result %s need %s", result, out)
+		}
+	}
+}


### PR DESCRIPTION
for multiarch tags, that was builded with buildx in single tag
```bash
docker buildx build --push \
--tag your-username/multiarch-example:latest \
--platform linux/amd64,linux/arm64 .
```
there is issue with garbage collection, when images builded with multiarch became broken after deleting with `--delete-untagged` https://github.com/distribution/distribution/issues/3178

to fix this - you need build multiarch images more harder
```bash
docker buildx build --push \
--tag your-username/multiarch-example:latest-amd64 \
--platform linux/amd64 .

docker buildx build --push \
--tag your-username/multiarch-example:latest-arm64 \
--platform linux/arm64 .

docker manifest create your-username/multiarch-example:latest \
--amend your-username/multiarch-example:latest-amd64 \
--amend your-username/multiarch-example:latest-amd64

docker manifest create your-username/multiarch-example:latest
```

in this PR was added new flag `-tag.arch` that will use this tag suffix in detection staled tags


Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>