### PR TITLE
filter repositories

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,7 +73,7 @@ func GetNotDeletableTags(input *GetNotDeletableTagsInput) []string {
 	for tag := range input.Tags {
 		releaseTag, err := GetReleaseTag(input.DateRegexp, tag)
 		if err != nil {
-			log.WithError(err).Error()
+			log.WithError(err).Debug("not release tag")
 
 			continue
 		}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -117,17 +117,17 @@ func TestGetNotDeletableSnapshotTags(t *testing.T) {
 
 	tags := make(map[string]types.TagType)
 
-	tags["20210316-snap"] = types.CanNotDelete
-	tags["20210421-snap"] = types.CanNotDelete
-	tags["20210504-snap"] = types.CanNotDelete
-	tags["20211117-snap"] = types.CanNotDelete
-	tags["20220331-snap"] = types.CanNotDelete
-	tags["20220415-snap"] = types.CanNotDelete
-	tags["20220606-snap"] = types.CanNotDelete
-	tags["20220615-snap"] = types.CanNotDelete
-	tags["20220809-snap"] = types.CanNotDelete
-	tags["20228899-snap"] = types.CanNotDelete // fake date
-	tags["90228809-snap"] = types.CanNotDelete // date in future
+	tags["20210316-snap"] = types.Unknown
+	tags["20210421-snap"] = types.Unknown
+	tags["20210504-snap"] = types.Unknown
+	tags["20211117-snap"] = types.Unknown
+	tags["20220331-snap"] = types.Unknown
+	tags["20220415-snap"] = types.Unknown
+	tags["20220606-snap"] = types.Unknown
+	tags["20220615-snap"] = types.Unknown
+	tags["20220809-snap"] = types.Unknown
+	tags["20228899-snap"] = types.Unknown // fake date
+	tags["90228809-snap"] = types.Unknown // date in future
 
 	result := api.GetNotDeletableTags(newSnapshotnput(tags))
 

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -99,10 +99,17 @@ func (p *Provider) Init(dryRun bool) error {
 }
 
 // List repositories.
-func (p *Provider) Repositories() ([]string, error) {
+func (p *Provider) Repositories(filter string) ([]string, error) {
 	repos, err := p.hub.Repositories()
+	if err != nil {
+		return nil, errors.Wrap(err, "can not get repositories")
+	}
 
-	return repos, errors.Wrap(err, "can not get repositories")
+	if len(filter) > 0 {
+		return utils.FilterStrings(repos, filter), nil
+	}
+
+	return repos, nil
 }
 
 // List tags.

--- a/pkg/providers/s3/s3.go
+++ b/pkg/providers/s3/s3.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/paskal-maksim/gitlab-registry-cleaner/pkg/types"
+	"github.com/paskal-maksim/gitlab-registry-cleaner/pkg/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -134,7 +135,7 @@ func (p *Provider) Init(dryRun bool) error {
 	return nil
 }
 
-func (p *Provider) Repositories() ([]string, error) {
+func (p *Provider) Repositories(filter string) ([]string, error) {
 	p.repositories = make(map[string]bool)
 
 	if err := p.listRepository(*registryFolder); err != nil {
@@ -145,6 +146,10 @@ func (p *Provider) Repositories() ([]string, error) {
 
 	for repo := range p.repositories {
 		repositories = append(repositories, repo)
+	}
+
+	if len(filter) > 0 {
+		return utils.FilterStrings(repositories, filter), nil
 	}
 
 	return repositories, nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -19,12 +19,13 @@ func (t TagType) String() string {
 }
 
 const (
-	CanNotDelete            TagType = "CanNotDelete"
+	Unknown                 TagType = "Unknown"
 	BranchNotFound          TagType = "BranchNotFound"
 	ReleaseTagCanNotDelete  TagType = "ReleaseTagCanNotDelete"
 	ReleaseTag              TagType = "ReleaseTag"
 	SystemTag               TagType = "SystemTag"
 	BranchStale             TagType = "BranchStale"
+	BranchNotStaled         TagType = "BranchNotStaled"
 	SnapshotTagCanNotDelete TagType = "SnapshotTagCanNotDelete"
 	SnapshotStaled          TagType = "SnapshotStaled"
 )
@@ -38,7 +39,7 @@ type Provider interface {
 	// Initialize provider
 	Init(dryRun bool) error
 	// List repositories in provider
-	Repositories() ([]string, error)
+	Repositories(filter string) ([]string, error)
 	// List tags in provider
 	Tags(repository string) ([]string, error)
 	// Delete tag

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -23,12 +23,15 @@ func TestTagType(t *testing.T) {
 
 	tests := make(map[types.TagType]string)
 
-	tests[types.CanNotDelete] = "CanNotDelete"
+	tests[types.Unknown] = "Unknown"
 	tests[types.BranchNotFound] = "BranchNotFound"
 	tests[types.ReleaseTagCanNotDelete] = "ReleaseTagCanNotDelete"
 	tests[types.ReleaseTag] = "ReleaseTag"
 	tests[types.SystemTag] = "SystemTag"
 	tests[types.BranchStale] = "BranchStale"
+	tests[types.BranchNotStaled] = "BranchNotStaled"
+	tests[types.SnapshotTagCanNotDelete] = "SnapshotTagCanNotDelete"
+	tests[types.SnapshotStaled] = "SnapshotStaled"
 
 	for in, out := range tests {
 		result := in.String()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -67,3 +67,18 @@ func GetEnv(key, fallback string) string {
 
 	return fallback
 }
+
+// Filter strings array by filter regexp.
+func FilterStrings(list []string, filter string) []string {
+	var result []string
+
+	regexFilter := regexp.MustCompile(filter)
+
+	for _, v := range list {
+		if regexFilter.MatchString(v) {
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -77,3 +77,17 @@ func TestGetEnv(t *testing.T) { //nolint:paralleltest
 		t.Fatal("GetEnv must return fallback")
 	}
 }
+
+func TestFilterStrings(t *testing.T) {
+	t.Parallel()
+
+	arr := []string{"test", "test1", "test2"}
+
+	if len(utils.FilterStrings(arr, "^test$")) != 1 {
+		t.Fatal("FilterStrings must return 1")
+	}
+
+	if len(utils.FilterStrings(arr, "^test.*$")) != 3 {
+		t.Fatal("FilterStrings must return 3")
+	}
+}


### PR DESCRIPTION
add flag `-registry.filter` to regexp filter all repositories

also some changes:
- reduce days that staled docker tag detected from 100 to 30 days
- rename CanNotDelete to Unknown
- extend log messages

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>