### PR TITLE
fix logic that store latest tags

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/paskal-maksim/gitlab-registry-cleaner/pkg/api"
 	"github.com/paskal-maksim/gitlab-registry-cleaner/pkg/gitlab"
@@ -51,7 +50,6 @@ var (
 	ignoreRepositoryPattern   = flag.String("ignoreTags", utils.GetEnv("IGNORE_TAGS", `^devops/docker$`), "")
 	releaseNotDeleteDays      = flag.Float64("release.daysNotDelete", defaultNotDeleteDays, "")
 	minNotDeleteReleaseTags   = flag.Int("release.minTags", defaultMinNotDeleteTags, "")
-	tagArch                   = flag.String("tag.arch", "amd64,arm64", "tag suffix for arch")
 	ciCheck                   = flag.Bool("ci.check", false, "check if release tag is valid")
 	ciTag                     = flag.String("ci.tag", os.Getenv("CI_COMMIT_REF_NAME"), "tag to check")
 	ciCommitDate              = flag.String("ci.commitDate", os.Getenv("CI_COMMIT_TIMESTAMP"), "commit date to check")
@@ -246,14 +244,12 @@ func getStaleDockerTags(registry types.Provider, repositories []string) ([]types
 			MinNotDeleteTags: *minNotDeleteReleaseTags,
 		})
 
-		supportedTagArch := strings.Split(*tagArch, ",")
-
 		// Calculate tags to delete
 		for projectAllDockerTag := range projectAllDockerTags {
 			var tagType types.TagType
 
 			// remove arch from docker tag name
-			tagWithoutArch := api.GetTagWithoutArch(projectAllDockerTag, supportedTagArch)
+			tagWithoutArch := api.GetTagWithoutArch(projectAllDockerTag)
 
 			if branchStale, ok := projectBranches[tagWithoutArch]; ok {
 				if branchStale.Staled {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -108,7 +108,7 @@ func TestGetNotDeletableReleaseTagsFrequent(t *testing.T) {
 	sort.Strings(result)
 
 	if !reflect.DeepEqual(result, need) {
-		t.Fatalf("tags not equals result=%v", result)
+		t.Fatalf("tags not equals \n(%v)<=result\n(%v)<=need", result, need)
 	}
 }
 
@@ -141,7 +141,7 @@ func TestGetNotDeletableSnapshotTags(t *testing.T) {
 	sort.Strings(result)
 
 	if !reflect.DeepEqual(result, need) {
-		t.Fatalf("tags not equals result=%v", result)
+		t.Fatalf("tags not equals \n(%v)<=result\n(%v)<=need", result, need)
 	}
 }
 
@@ -151,23 +151,37 @@ func TestGetNotDeletableReleaseTagsRare(t *testing.T) {
 	tags := make(map[string]types.TagType)
 
 	tags["release-20220320"] = types.ReleaseTag
+	tags["release-20220320-amd64"] = types.ReleaseTag
+	tags["release-20220320-arm64"] = types.ReleaseTag
 	tags["release-20220219"] = types.ReleaseTag
+	tags["release-20220219-amd64"] = types.ReleaseTag
+	tags["release-20220219-arm64"] = types.ReleaseTag
 	tags["release-20220118"] = types.ReleaseTag
+	tags["release-20220118-amd64"] = types.ReleaseTag
+	tags["release-20220118-arm64"] = types.ReleaseTag
 	tags["release-20211217"] = types.ReleaseTag
+	tags["release-20211217-amd64"] = types.ReleaseTag
+	tags["release-20211217-arm64"] = types.ReleaseTag
 
 	result := api.GetNotDeletableTags(newReleaseInput(tags))
 
 	need := []string{
 		"release-20220320",
+		"release-20220320-amd64",
+		"release-20220320-arm64",
 		"release-20220219",
+		"release-20220219-amd64",
+		"release-20220219-arm64",
 		"release-20220118",
+		"release-20220118-amd64",
+		"release-20220118-arm64",
 	}
 
 	sort.Strings(need)
 	sort.Strings(result)
 
 	if !reflect.DeepEqual(result, need) {
-		t.Fatalf("tags not equals result=%v", result)
+		t.Fatalf("tags not equals \n(%v)<=result\n(%v)<=need", result, need)
 	}
 }
 
@@ -188,10 +202,8 @@ func TestGetTagWithoutArch(t *testing.T) {
 	tests["test2-arm64"] = "test2"
 	tests["test3-amd64"] = "test3"
 
-	tagArch := []string{"amd64", "arm64"}
-
 	for in, out := range tests {
-		result := api.GetTagWithoutArch(in, tagArch)
+		result := api.GetTagWithoutArch(in)
 		if result != out {
 			t.Fatalf("result %s need %s", result, out)
 		}
@@ -269,5 +281,34 @@ func TestCheckReleaseTag(t *testing.T) { //nolint:funlen
 		if err == nil {
 			t.Fatal("error must be " + test.Tag)
 		}
+	}
+}
+
+func TestGetFormattedTags(t *testing.T) {
+	t.Parallel()
+
+	tags := []string{
+		"main",
+		"release-20221226-1-master",
+		"release-20221226-1-master-amd64",
+		"release-20221226-1-master-arm64",
+		"release-20230106-master",
+		"release-20230106-master-amd64",
+		"release-20230106-master-arm64",
+	}
+
+	result := api.GetTagsWithoutArch(tags)
+
+	need := []string{
+		"release-20221226-1-master",
+		"release-20230106-master",
+		"main",
+	}
+
+	sort.Strings(need)
+	sort.Strings(result)
+
+	if !reflect.DeepEqual(result, need) {
+		t.Fatalf("tags not equals \n(%v)<=result\n(%v)<=need", result, need)
 	}
 }


### PR DESCRIPTION
fixing an issue with multiarch tags, logic in `api.GetNotDeletableTags` must return tags that can't be deleted, if registry have multiple tags, this function not working correcty.

add tests, to cover this issue

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>