### PR TITLE
fix context deadlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ test:
 	go fmt ./cmd/... ./pkg/... ./internal/...
 	go vet ./cmd/... ./pkg/... ./internal/...
 	go test -race -coverprofile coverage.out ./cmd/... ./pkg/... ./internal/...
+	# test ci check on valid tag
+	CI_COMMIT_REF_NAME=release-20230515-test \
+	CI_COMMIT_TIMESTAMP="2023-05-12T08:56:11Z" \
+	go run ./cmd/main/main.go -ci.check
 	go mod tidy
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run -v
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -78,7 +78,4 @@ func main() {
 	if err := internal.Run(ctx); err != nil {
 		log.WithError(err).Fatal()
 	}
-
-	<-ctx.Done()
-	time.Sleep(gracefulShutdownTimeout)
 }


### PR DESCRIPTION
fix
```
Tag release-20230515-test is valid
fatal error: all goroutines are asleep - deadlock!
goroutine 1 [chan receive]:
main.main()
	github.com/paskal-maksim/gitlab-registry-cleaner/cmd/main/main.go:82 +0x41c
```